### PR TITLE
Provu cron remove

### DIFF
--- a/Cron/Orders.php
+++ b/Cron/Orders.php
@@ -29,7 +29,7 @@ class Orders
      */
     public function execute()
     {
-        $this->logger->addInfo("Cronjob Orders is executed.");
+       // $this->logger->addInfo("Cronjob Orders is executed.");
     }
 }
 

--- a/Cron/OrdersRemove.php
+++ b/Cron/OrdersRemove.php
@@ -1,0 +1,118 @@
+<?php
+/**
+ * Copyright ©  All rights reserved.
+ * See COPYING.txt for license details.
+ */
+declare(strict_types=1);
+
+namespace Milabs\Provu\Cron;
+
+use DateInterval;
+use Magento\Framework\Exception\LocalizedException;
+
+class OrdersRemove
+{
+
+    const CODE = \Milabs\Provu\Model\Payment\Provu::CODE;
+
+    protected $logger;
+    protected $orderPayment;
+    protected $orderFactory;
+    protected $dateTime;
+    protected $helper;
+    /**
+     * Constructor
+     *
+     * @param \Psr\Log\LoggerInterface $logger
+     */
+    public function __construct(
+        \Psr\Log\LoggerInterface $logger,
+        \Magento\Sales\Model\ResourceModel\Order\CollectionFactory $orderFactory,
+        \Magento\Sales\Model\ResourceModel\Order\Payment\Collection $paymentCollection,
+        \Magento\Framework\Stdlib\DateTime\DateTime $dateTime,
+        \Milabs\Provu\Helper\Data $helper
+        )
+    {
+        $this->orderPayment = $paymentCollection;
+        $this->orderFactory = $orderFactory;
+        $this->logger = $logger;
+        $this->dateTime = $dateTime;
+        $this->helper = $helper;
+    }
+
+    public function run()
+    {
+        $retorna = [];
+        foreach( $this->getParentIds() as $orders )
+        {   
+            $order = $this->getOrder($orders);
+            $dataAt = explode(" ",$order->getData('created_at'))[0];
+            if ($order->getData('state') == \Magento\Sales\Model\Order::STATE_PENDING_PAYMENT){
+                
+                if($this->compareDate($dataAt))
+                {
+                    $order->setState(\Magento\Sales\Model\Order::STATE_CANCELED);
+                    $order->setStatus(\Magento\Sales\Model\Order::STATE_CANCELED);
+                    $order->save();
+                }
+
+                $retorna[$orders] = ['state'=>$order->getData('state'), 'date'=>$this->getDateAt($dataAt),'dateAt'=>$this->getDateAt(),'expired'=>$this->compareDate($dataAt)];
+            }
+
+        }
+            
+            $file = fopen('/var/www/html/teste.txt', 'w+');
+            fwrite($file, json_encode((array)$retorna, JSON_PRETTY_PRINT));
+            fclose($file); 
+    }
+
+    protected function getParentIds()
+    {
+        try{
+            $return = [];
+            foreach( $this->getPaymentColection()->getItems() as $key => $value ){
+                $paymentOrder = $this->getPaymentColection()->getItemById($key);
+                if( $paymentOrder->getData('method') === self::CODE ){
+                    array_push($return, $paymentOrder->getData('parent_id') ) ;
+                }
+            }
+            return $return;
+        }
+        catch(LocalizedException $e)
+        {
+            $this->logger->warning(__(
+                "[M!labs Updater] - ",
+                $e->getMessage()
+            ));
+        }
+    }
+
+    protected function compareDate($date)
+    {
+        $dateCreate = strtotime(date('Y-m-d',strtotime('+'.$this->helper->getDaysCron().' day', strtotime($date))));
+        $dateNow = strtotime($this->getDateAt());
+        if($dateNow > $dateCreate)
+        {
+            return true;
+        }
+        return false;
+    }
+
+    protected function getDateAt($date = null)
+    {
+        return $this->dateTime->gmtDate('Y-m-d',$date);
+    }
+
+    public function getOrder($condition)
+    {
+        return $this->orderFactory->create()->getItemById($condition);
+    }
+    
+    protected function getPaymentColection()
+    {
+        return $this->orderPayment->loadData();
+    }
+
+
+}
+

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -140,6 +140,16 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return (string)$config;
     }
 
+    /**
+     * @return int
+     */
+    public function getDaysCron()
+    {
+        $config = $this->scopeConfig->getValue(
+            'payment/provu/days_cron'
+        );
+        return (int)$config;
+    }
 
     /**
      * @return string

--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Magento 2.x
 ## Instalação via composer
  - `composer require milabs/module-provu`
  - `bin/magento setup:upgrade`
- - `bin/magento setup:di:copile`
  - `bin/magento setup:static-content:deploy -f pt_BR`
  - `bin/magento cache:clean`
 

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -23,6 +23,10 @@
 				<field id="api_token" type="text" sortOrder="50" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
 					<label>Api Token</label>
 				</field>
+				<field id="days_cron" type="text" sortOrder="50" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
+					<label>Remoção de pedidos</label>
+					<comment>Numero de dias para remoção de pedidos com status pendente pagamento.</comment>
+				</field>
 				<field id="sort_order" type="text" sortOrder="60" showInWebsite="1" showInStore="1" showInDefault="1" translate="label">
 					<label>Sort Order</label>
 				</field>

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,6 +8,7 @@
 				<order_status>pending</order_status>
 				<title>Provu</title>
 				<allowspecific>0</allowspecific>
+				<days_cron>3</days_cron>
 				<payment_action>order</payment_action>
 			</provu>
 		</payment>

--- a/etc/crontab.xml
+++ b/etc/crontab.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Cron:etc/crontab.xsd">
+
 	<group id="default">
+	
 		<job name="zafarie_provu_orders" instance="Milabs\Provu\Cron\Orders" method="execute">
 			<schedule>*/15 * * * *</schedule>
 		</job>
+
+		<job name="milabs_provu_remove_orders" instance="Milabs\Provu\Cron\OrdersRemove" method="run">
+			<schedule>0 */12 * * * </schedule>
+		</job>
+
 	</group>
+
 </config>
+

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Milabs_Provu" setup_version="1.00.01" >
+	<module name="Milabs_Provu" setup_version="1.00.02" >
 		<sequence>
 			<module name="Magento_Sales"/>
 		</sequence>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,10 +1,8 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-
 	<module name="Milabs_Provu" setup_version="1.00.01" >
 		<sequence>
 			<module name="Magento_Sales"/>
 		</sequence>
 	</module>
-
 </config>


### PR DESCRIPTION
Criado rotina para cancelar pedidos com mais de 3 dias sem mudança de status. Pedidos com o status de Pendente Pagamento com mais de três dias serão cancelados automaticamente, podendo ser mudado a quantidades de dias via configuração do modulo!